### PR TITLE
chore: upgrade SharePoint CSOM packages

### DIFF
--- a/CSOM File Add Test/CSOM File Add Test.csproj
+++ b/CSOM File Add Test/CSOM File Add Test.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/CSOM File Add Test/packages.config
+++ b/CSOM File Add Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.25110.12000" targetFramework="net48" />
+  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.27518.12000" targetFramework="net48" />
 </packages>

--- a/CSOM Taxonomy Field Update/Taxonomy API/Taxonomy API/Taxonomy API.csproj
+++ b/CSOM Taxonomy Field Update/Taxonomy API/Taxonomy API/Taxonomy API.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/CSOM Taxonomy Field Update/Taxonomy API/Taxonomy API/packages.config
+++ b/CSOM Taxonomy Field Update/Taxonomy API/Taxonomy API/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.25110.12000" targetFramework="net48" />
+  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.27518.12000" targetFramework="net48" />
 </packages>

--- a/CSOM_CheckPermission/CSOM_CheckPermission.csproj
+++ b/CSOM_CheckPermission/CSOM_CheckPermission.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/CSOM_CheckPermission/packages.config
+++ b/CSOM_CheckPermission/packages.config
@@ -16,7 +16,7 @@
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Logging" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.2.4" targetFramework="net461" />
-  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.25110.12000" targetFramework="net48" />
+  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.27518.12000" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
   <package id="SharePointPnP.IdentityModel.Extensions" version="1.2.4" targetFramework="net461" />
   <package id="SharePointPnPCoreOnline" version="3.28.2012" targetFramework="net461" />

--- a/CSOM_ExceptionHandlingScope_Test/CSOM_ExceptionHandlingScope_Test.csproj
+++ b/CSOM_ExceptionHandlingScope_Test/CSOM_ExceptionHandlingScope_Test.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/CSOM_ExceptionHandlingScope_Test/packages.config
+++ b/CSOM_ExceptionHandlingScope_Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.25110.12000" targetFramework="net48" />
+  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.27518.12000" targetFramework="net48" />
 </packages>

--- a/CSOM_View_Test/CSOM_View_Test.csproj
+++ b/CSOM_View_Test/CSOM_View_Test.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/CSOM_View_Test/packages.config
+++ b/CSOM_View_Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.25110.12000" targetFramework="net48" />
+  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.27518.12000" targetFramework="net48" />
 </packages>

--- a/ExportCsomToken/ExportCsomToken.csproj
+++ b/ExportCsomToken/ExportCsomToken.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.77.0" />
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25912.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ListSPEmbeddedContains/ListSPEmbeddedContains.csproj
+++ b/ListSPEmbeddedContains/ListSPEmbeddedContains.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SPListApiTest/SPListApiTest.csproj
+++ b/SPListApiTest/SPListApiTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SetColumnDefaultValue/SetColumnDefaultValue.csproj
+++ b/SetColumnDefaultValue/SetColumnDefaultValue.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharePoint Query Test/CamlQueryTest/CamlQueryTest.csproj
+++ b/SharePoint Query Test/CamlQueryTest/CamlQueryTest.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/SharePoint Query Test/CamlQueryTest/packages.config
+++ b/SharePoint Query Test/CamlQueryTest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.25110.12000" targetFramework="net48" />
+  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.27518.12000" targetFramework="net48" />
 </packages>

--- a/SharePoint Query Test/SharePoint Query Test/SharePoint Query Test.csproj
+++ b/SharePoint Query Test/SharePoint Query Test/SharePoint Query Test.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/TenantApiTest/TenantApiTest.csproj
+++ b/TenantApiTest/TenantApiTest.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/TenantApiTest/packages.config
+++ b/TenantApiTest/packages.config
@@ -44,7 +44,7 @@
   <package id="Microsoft.IdentityModel.Logging" version="6.35.0" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.Tokens" version="6.35.0" targetFramework="net48" />
   <package id="Microsoft.Net.Http.Headers" version="2.2.0" targetFramework="net48" />
-  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.25110.12000" targetFramework="net48" />
+  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.27518.12000" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
   <package id="PnP.Core" version="1.14.0" targetFramework="net48" />
   <package id="PnP.Framework" version="1.17.0" targetFramework="net48" />

--- a/TimeZoneTest/TimeZoneTest.csproj
+++ b/TimeZoneTest/TimeZoneTest.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/UpdateConlictSample/UpdateConflictSample.csproj
+++ b/UpdateConlictSample/UpdateConflictSample.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/UpdateConlictSample/packages.config
+++ b/UpdateConlictSample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.25110.12000" targetFramework="net48" />
+  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.27518.12000" targetFramework="net48" />
 </packages>

--- a/UpdateWebAllProperties/UpdateWebAllProperties.csproj
+++ b/UpdateWebAllProperties/UpdateWebAllProperties.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.25110.12000" />
+    <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.27518.12000" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/UpdateWebAllProperties/packages.config
+++ b/UpdateWebAllProperties/packages.config
@@ -16,7 +16,7 @@
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.2.4" targetFramework="net472" />
   <package id="Microsoft.IdentityModel.Logging" version="5.2.4" targetFramework="net472" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.2.4" targetFramework="net472" />
-  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.25110.12000" targetFramework="net472" />
+  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.27518.12000" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net472" />
   <package id="SharePointPnP.IdentityModel.Extensions" version="1.2.4" targetFramework="net472" />
   <package id="SharePointPnPCoreOnline" version="3.28.2012" targetFramework="net472" />


### PR DESCRIPTION
## Summary
- bump every Microsoft.SharePointOnline.CSOM reference to version 16.1.27518.12000 across project files and packages.config

## Testing
- not run (dotnet CLI is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d74b059d84832ebbe5c8c5ba9b40d0